### PR TITLE
End of support for Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ references:
   - &ruby_version
     ruby_version:
       type: enum
-      enum: ['2.4', '2.5', '2.6', 'latest']
-      default: '2.4'
+      enum: ['2.5', '2.6', '2.7', 'latest']
+      default: '2.5'
 
 executors:
   default:
@@ -156,14 +156,14 @@ workflows:
   commit:
     jobs:
       - build:
-          name: build_on_ruby_2.4
-          ruby_version: '2.4'
-      - build:
           name: build_on_ruby_2.5
           ruby_version: '2.5'
       - build:
           name: build_on_ruby_2.6
           ruby_version: '2.6'
+      - build:
+          name: build_on_ruby_2.7
+          ruby_version: '2.7'
       - build:
           name: build_on_ruby_latest
           ruby_version: 'latest'
@@ -171,16 +171,16 @@ workflows:
       - yardoc
       - upload-coverage:
           requires:
-            - build_on_ruby_2.4
             - build_on_ruby_2.5
             - build_on_ruby_2.6
+            - build_on_ruby_2.7
             - build_on_ruby_latest
       - release:
           context: RubyGems API Key
           requires:
-            - build_on_ruby_2.4
             - build_on_ruby_2.5
             - build_on_ruby_2.6
+            - build_on_ruby_2.7
             - build_on_ruby_latest
             - rubocop
           filters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics/BlockLength:
   Exclude:


### PR DESCRIPTION
See: https://www.ruby-lang.org/ja/news/2020/04/05/support-of-ruby-2-4-has-ended/